### PR TITLE
Update GeoTools repository

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,14 +18,9 @@
       <url>https://josm.openstreetmap.de/nexus/content/repositories/releases/</url>
     </repository>
     <repository>
-      <id>osgeo</id>
-      <name>Geotools repository</name>
-      <url>http://repo.boundlessgeo.com/main/</url>
-    </repository>
-    <repository>
-      <id>GeoMajas</id>
-      <name>GeoMajas</name>
-      <url>http://maven.geomajas.org/</url>
+      <id>OSGeo</id>
+      <name>OSGeo</name>
+      <url>https://repo.osgeo.org/repository/release/</url>
     </repository>
     <repository>
       <id>github_hss</id>
@@ -158,7 +153,7 @@
     <dependency>
       <groupId>org.geotools</groupId>
       <artifactId>gt-shapefile</artifactId>
-      <version>22.2</version>
+      <version>26.3</version>
     </dependency>
     <!-- https://mvnrepository.com/artifact/io.github.g00fy2/versioncompare -->
     <dependency>


### PR DESCRIPTION
The repositories previously used for fetching GeoTools libraries
are no longer available. Change to the OSGeo Maven repository
and update the shapefile library version to work with it.